### PR TITLE
fix: use stable rust toolchain in version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          toolchain: stable
       
       - name: Install cargo-edit
         run: cargo install cargo-edit

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,7 +20,15 @@ permissions:
 
 jobs:
   version-bump:
-    if: github.event_name == 'workflow_dispatch' || (contains(github.event.pull_request.labels.*.name, 'release') && !contains(github.event.head_commit.message, 'bump version'))
+    # Only run if:
+    # 1. It's a workflow_dispatch event OR
+    # 2. It's a label event with 'release' label AND the commit doesn't contain 'bump version' AND
+    #    we haven't already processed this PR (checking automated label)
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'release') &&
+       !contains(github.event.head_commit.message, 'bump version') &&
+       !contains(github.event.pull_request.labels.*.name, 'automated'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.goosehints
+++ b/.goosehints
@@ -1,70 +1,89 @@
-This is Essex, a Docker project template generator written in Rust. It helps create consistent and well-structured Docker projects.
+# Essex AI Assistant Guidelines
 
-# Project Context
-- Essex is designed to generate Docker projects from templates with a focus on best practices and consistency
-- The project uses Tera templating (Jinja2-like syntax) for template generation
-- The main binary is written in Rust and requires Rust 1.70 or later
+## Project Identity
+Essex is a Rust-based Docker project template generator focused on consistency and best practices.
 
-# Project Structure
-- `/src`: Contains the Rust source code for the Essex binary
-- `/templates`: Contains the template definitions
-  - `/templates/basic`: The basic template which includes Dockerfile, Makefile, README.md, and runtime assets
-- Each generated project follows a consistent structure with:
-  - Dockerfile (uses best practices and OCI-compliant labels)
-  - Makefile (for common Docker operations)
-  - README.md
-  - runtime-assets (containing entrypoint scripts and other assets)
+## Code Style Requirements
+1. ALWAYS enforce these Rust formatting rules:
+    ```toml
+    # .rustfmt.toml settings
+    max_width = 100
+    hard_tabs = false
+    tab_spaces = 4
+    newline_style = "Auto"
+    use_small_heuristics = "Default"
+    reorder_imports = true
+    reorder_modules = true
+    remove_nested_parens = true
+    edition = "2021"
+    merge_derives = true
+    use_field_init_shorthand = true
+    use_try_shorthand = true
+    force_explicit_abi = true
+    ```
 
-# Development Guidelines
-- Follow Test-Driven Development (TDD) practices:
-  - Write tests first before implementing new features
-  - Ensure each new feature or bug fix has corresponding tests
-  - Keep test coverage high and meaningful
-- All code changes should maintain backward compatibility with existing templates
-- Follow Rust best practices and idiomatic code patterns
-- Ensure all templates follow Docker best practices:
-  - Use multi-stage builds where appropriate
-  - Include proper OCI labels
-  - Follow principle of least privilege (run as non-root user)
-  - Include proper documentation
-- Always ensure our cargo version matches our git tag for releases
+2. ALWAYS enforce these Clippy rules via RUSTFLAGS:
+    ```bash
+    RUSTFLAGS="-D warnings -D clippy::redundant-pattern-matching -D clippy::needless-borrows-for-generic-args"
+    ```
 
-# Testing Requirements
-- Run `cargo test` to ensure all tests pass before submitting changes
-- Test template generation with different parameters
-- Verify generated Dockerfiles can be built successfully
-- Check that Makefiles in templates work as expected
+## Development Rules
+1. NEVER skip running these checks before committing:
+   - `cargo fmt --all -- --check`
+   - `cargo clippy` with required RUSTFLAGS
+   - `cargo test`
 
-# Important Files
-- README.md: Primary documentation source
-- src/main.rs: Entry point for the Essex binary
-- templates/basic/*: Core template files that serve as examples
+2. ALWAYS maintain these standards:
+   - Write tests before implementing features (TDD)
+   - Keep backward compatibility with existing templates
+   - Follow idiomatic Rust patterns
+   - Match cargo version with git tags for releases
 
-# Build Process
-- Use `cargo build --release` for production builds
-- Development builds can use `cargo build`
-- Generated projects use Make for building Docker images
+3. ALWAYS follow these Docker best practices:
+   - Use multi-stage builds
+   - Include OCI labels
+   - Run as non-root user
+   - Provide comprehensive documentation
 
-# Template Variables
-The following variables are commonly used in templates:
-- repo_username: GitHub/container registry username
-- repo_namespace: Organization/namespace for the project
-- image_name: Name of the Docker image
-- vendor: Company/organization name
-- version: Project version
-- build_date: Build timestamp
-- vcs_ref: Git commit reference
+## Template Rules
+1. ALWAYS include these components in generated projects:
+   - Dockerfile with best practices
+   - Makefile for Docker operations
+   - README.md
+   - runtime-assets directory
 
-# Best Practices
-- Keep templates minimal but functional
-- Ensure all generated projects include proper documentation
-- Follow security best practices in Dockerfile templates
-- Include comprehensive error handling in Rust code
-- Document any new template variables or features
+2. ALWAYS support these template variables:
+   - repo_username
+   - repo_namespace
+   - image_name
+   - vendor
+   - version
+   - build_date
+   - vcs_ref
 
-When working with this project, please:
-1. Consult the README.md first for basic information
-2. Run tests before making any changes
-3. Maintain the existing project structure
-4. Follow the established coding style and practices
-5. Update documentation when adding new features
+## Documentation Rules
+1. ALWAYS update documentation when:
+   - Adding new features
+   - Modifying template variables
+   - Changing project structure
+   - Updating dependencies
+
+2. ALWAYS maintain these files:
+   - README.md for project overview
+   - CONTRIBUTING.md for development guidelines
+   - Template-specific documentation
+
+## Error Handling Rules
+1. ALWAYS provide:
+   - Clear error messages
+   - Proper error types
+   - Recovery suggestions
+   - Debug information when appropriate
+
+## Testing Rules
+1. ALWAYS verify:
+   - Template generation with various parameters
+   - Docker build success for generated projects
+   - Makefile functionality
+   - Unit test coverage
+   - Integration test coverage

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,13 @@
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+use_small_heuristics = "Default"
+reorder_imports = true
+reorder_modules = true
+remove_nested_parens = true
+edition = "2021"
+merge_derives = true
+use_field_init_shorthand = true
+use_try_shorthand = true
+force_explicit_abi = true

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,70 +1,89 @@
-This is Essex, a Docker project template generator written in Rust. It helps create consistent and well-structured Docker projects.
+# Essex AI Assistant Guidelines
 
-# Project Context
-- Essex is designed to generate Docker projects from templates with a focus on best practices and consistency
-- The project uses Tera templating (Jinja2-like syntax) for template generation
-- The main binary is written in Rust and requires Rust 1.70 or later
+## Project Identity
+Essex is a Rust-based Docker project template generator focused on consistency and best practices.
 
-# Project Structure
-- `/src`: Contains the Rust source code for the Essex binary
-- `/templates`: Contains the template definitions
-  - `/templates/basic`: The basic template which includes Dockerfile, Makefile, README.md, and runtime assets
-- Each generated project follows a consistent structure with:
-  - Dockerfile (uses best practices and OCI-compliant labels)
-  - Makefile (for common Docker operations)
-  - README.md
-  - runtime-assets (containing entrypoint scripts and other assets)
+## Code Style Requirements
+1. ALWAYS enforce these Rust formatting rules:
+    ```toml
+    # .rustfmt.toml settings
+    max_width = 100
+    hard_tabs = false
+    tab_spaces = 4
+    newline_style = "Auto"
+    use_small_heuristics = "Default"
+    reorder_imports = true
+    reorder_modules = true
+    remove_nested_parens = true
+    edition = "2021"
+    merge_derives = true
+    use_field_init_shorthand = true
+    use_try_shorthand = true
+    force_explicit_abi = true
+    ```
 
-# Development Guidelines
-- Follow Test-Driven Development (TDD) practices:
-  - Write tests first before implementing new features
-  - Ensure each new feature or bug fix has corresponding tests
-  - Keep test coverage high and meaningful
-- All code changes should maintain backward compatibility with existing templates
-- Follow Rust best practices and idiomatic code patterns
-- Ensure all templates follow Docker best practices:
-  - Use multi-stage builds where appropriate
-  - Include proper OCI labels
-  - Follow principle of least privilege (run as non-root user)
-  - Include proper documentation
-- Always ensure our cargo version matches our git tag for releases
+2. ALWAYS enforce these Clippy rules via RUSTFLAGS:
+    ```bash
+    RUSTFLAGS="-D warnings -D clippy::redundant-pattern-matching -D clippy::needless-borrows-for-generic-args"
+    ```
 
-# Testing Requirements
-- Run `cargo test` to ensure all tests pass before submitting changes
-- Test template generation with different parameters
-- Verify generated Dockerfiles can be built successfully
-- Check that Makefiles in templates work as expected
+## Development Rules
+1. NEVER skip running these checks before committing:
+   - `cargo fmt --all -- --check`
+   - `cargo clippy` with required RUSTFLAGS
+   - `cargo test`
 
-# Important Files
-- README.md: Primary documentation source
-- src/main.rs: Entry point for the Essex binary
-- templates/basic/*: Core template files that serve as examples
+2. ALWAYS maintain these standards:
+   - Write tests before implementing features (TDD)
+   - Keep backward compatibility with existing templates
+   - Follow idiomatic Rust patterns
+   - Match cargo version with git tags for releases
 
-# Build Process
-- Use `cargo build --release` for production builds
-- Development builds can use `cargo build`
-- Generated projects use Make for building Docker images
+3. ALWAYS follow these Docker best practices:
+   - Use multi-stage builds
+   - Include OCI labels
+   - Run as non-root user
+   - Provide comprehensive documentation
 
-# Template Variables
-The following variables are commonly used in templates:
-- repo_username: GitHub/container registry username
-- repo_namespace: Organization/namespace for the project
-- image_name: Name of the Docker image
-- vendor: Company/organization name
-- version: Project version
-- build_date: Build timestamp
-- vcs_ref: Git commit reference
+## Template Rules
+1. ALWAYS include these components in generated projects:
+   - Dockerfile with best practices
+   - Makefile for Docker operations
+   - README.md
+   - runtime-assets directory
 
-# Best Practices
-- Keep templates minimal but functional
-- Ensure all generated projects include proper documentation
-- Follow security best practices in Dockerfile templates
-- Include comprehensive error handling in Rust code
-- Document any new template variables or features
+2. ALWAYS support these template variables:
+   - repo_username
+   - repo_namespace
+   - image_name
+   - vendor
+   - version
+   - build_date
+   - vcs_ref
 
-When working with this project, please:
-1. Consult the README.md first for basic information
-2. Run tests before making any changes
-3. Maintain the existing project structure
-4. Follow the established coding style and practices
-5. Update documentation when adding new features
+## Documentation Rules
+1. ALWAYS update documentation when:
+   - Adding new features
+   - Modifying template variables
+   - Changing project structure
+   - Updating dependencies
+
+2. ALWAYS maintain these files:
+   - README.md for project overview
+   - CONTRIBUTING.md for development guidelines
+   - Template-specific documentation
+
+## Error Handling Rules
+1. ALWAYS provide:
+   - Clear error messages
+   - Proper error types
+   - Recovery suggestions
+   - Debug information when appropriate
+
+## Testing Rules
+1. ALWAYS verify:
+   - Template generation with various parameters
+   - Docker build success for generated projects
+   - Makefile functionality
+   - Unit test coverage
+   - Integration test coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Essex
+
+Thank you for your interest in contributing to Essex! This document provides guidelines and setup instructions for contributing to the project.
+
+## Development Setup
+
+### Rust Toolchain Requirements
+- Rust version: 1.83.0 or later
+- Use stable toolchain features only
+
+### Code Style and Linting
+
+#### Rustfmt Configuration
+We use a `.rustfmt.toml` with stable-only features. The configuration is:
+```toml
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+use_small_heuristics = "Default"
+reorder_imports = true
+reorder_modules = true
+remove_nested_parens = true
+edition = "2021"
+merge_derives = true
+use_field_init_shorthand = true
+use_try_shorthand = true
+force_explicit_abi = true
+```
+
+#### Clippy Configuration
+Run clippy with these specific flags (via RUSTFLAGS):
+```bash
+RUSTFLAGS="-D warnings -D clippy::redundant-pattern-matching -D clippy::needless-borrows-for-generic-args"
+```
+
+## Development Workflow
+
+### Before Submitting Changes
+1. Run `cargo fmt --all -- --check` to verify formatting
+2. Run clippy with required flags:
+   ```bash
+   RUSTFLAGS="-D warnings -D clippy::redundant-pattern-matching -D clippy::needless-borrows-for-generic-args" cargo clippy
+   ```
+3. Run `cargo test` to ensure all tests pass
+
+### Pull Request Process
+1. Create a new branch for your changes
+2. Make your changes following the code style guidelines
+3. Update documentation as needed
+4. Submit a pull request
+5. Ensure CI checks pass
+
+## CI/CD Configuration
+Our CI environment uses:
+- Rust toolchain: stable (1.83.0)
+- Same rustfmt configuration via .rustfmt.toml
+- Same clippy flags via RUSTFLAGS environment variable
+
+## Additional Resources
+- [Rust Style Guide](https://rust-lang.github.io/api-guidelines/)
+- [Clippy Documentation](https://rust-lang.github.io/rust-clippy/)
+- [Rustfmt Documentation](https://rust-lang.github.io/rustfmt/)

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+warn-on-all-wildcard-imports = true
+redundant-pattern-matching-deny = true
+needless-borrows-for-generic-args-deny = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,0 @@
-warn-on-all-wildcard-imports = true
-redundant-pattern-matching-deny = true
-needless-borrows-for-generic-args-deny = true

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -212,14 +212,9 @@ mod tests {
         }
 
         // Test zsh completion with output
-        let cli = Cli::try_parse_from(&[
-            "essex",
-            "completion",
-            "zsh",
-            "--output",
-            "/tmp/completions",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(&["essex", "completion", "zsh", "--output", "/tmp/completions"])
+                .unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Zsh));
@@ -238,27 +233,16 @@ mod tests {
         assert!(cli.execute().is_ok());
 
         // Test new command with invalid template
-        let cli = Cli::try_parse_from(&[
-            "essex",
-            "new",
-            "non-existent",
-            "test/project",
-        ])
-        .unwrap();
+        let cli = Cli::try_parse_from(&["essex", "new", "non-existent", "test/project"]).unwrap();
         assert!(cli.execute().is_err());
 
         // Test completion command
         let completion_dir = temp_dir.path().join("completions");
         fs::create_dir(&completion_dir)?;
-        
-        let cli = Cli::try_parse_from(&[
-            "essex",
-            "completion",
-            "bash",
-            "--output",
-            completion_dir.to_str().unwrap(),
-        ])
-        .unwrap();
+
+        let cli =
+            Cli::try_parse_from(&["essex", "completion", "zsh", "--output", "/tmp/completions"])
+                .unwrap();
         assert!(cli.execute().is_ok());
 
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -212,8 +212,14 @@ mod tests {
         }
 
         // Test zsh completion with output
-        let cli = Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
-            .unwrap();
+        let cli = Cli::try_parse_from([
+            "essex",
+            "completion",
+            "zsh",
+            "--output",
+            "/tmp/completions",
+        ])
+        .unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Zsh));
@@ -239,8 +245,14 @@ mod tests {
         let completion_dir = temp_dir.path().join("completions");
         fs::create_dir(&completion_dir)?;
 
-        let cli = Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
-            .unwrap();
+        let cli = Cli::try_parse_from([
+            "essex",
+            "completion",
+            "zsh",
+            "--output",
+            "/tmp/completions",
+        ])
+        .unwrap();
         assert!(cli.execute().is_ok());
 
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -212,14 +212,9 @@ mod tests {
         }
 
         // Test zsh completion with output
-        let cli = Cli::try_parse_from([
-            "essex",
-            "completion",
-            "zsh",
-            "--output",
-            "/tmp/completions",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
+                .unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Zsh));
@@ -245,14 +240,9 @@ mod tests {
         let completion_dir = temp_dir.path().join("completions");
         fs::create_dir(&completion_dir)?;
 
-        let cli = Cli::try_parse_from([
-            "essex",
-            "completion",
-            "zsh",
-            "--output",
-            "/tmp/completions",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
+                .unwrap();
         assert!(cli.execute().is_ok());
 
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -142,16 +142,37 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::{Parser, ValueEnum};
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_list_command_parsing() {
-        let cli = Cli::try_parse_from(["essex", "list"]).unwrap();
+        let cli = Cli::try_parse_from(&["essex", "list"]).unwrap();
         assert!(matches!(cli.command, Commands::List));
     }
 
     #[test]
     fn test_new_command_parsing() {
-        let cli = Cli::try_parse_from([
+        // Test basic new command
+        let cli = Cli::try_parse_from(&["essex", "new", "basic", "test/project"]).unwrap();
+        match cli.command {
+            Commands::New {
+                template,
+                project,
+                username,
+                vendor,
+            } => {
+                assert_eq!(template, "basic");
+                assert_eq!(project, "test/project");
+                assert!(username.is_none());
+                assert!(vendor.is_none());
+            }
+            _ => panic!("Expected New command"),
+        }
+
+        // Test new command with all options
+        let cli = Cli::try_parse_from(&[
             "essex",
             "new",
             "basic",
@@ -162,7 +183,6 @@ mod tests {
             "Test Corp",
         ])
         .unwrap();
-
         match cli.command {
             Commands::New {
                 template,
@@ -172,8 +192,8 @@ mod tests {
             } => {
                 assert_eq!(template, "basic");
                 assert_eq!(project, "test/project");
-                assert_eq!(username, Some("testuser".to_string()));
-                assert_eq!(vendor, Some("Test Corp".to_string()));
+                assert_eq!(username.unwrap(), "testuser");
+                assert_eq!(vendor.unwrap(), "Test Corp");
             }
             _ => panic!("Expected New command"),
         }
@@ -181,7 +201,8 @@ mod tests {
 
     #[test]
     fn test_completion_command_parsing() {
-        let cli = Cli::try_parse_from(["essex", "completion", "bash"]).unwrap();
+        // Test bash completion
+        let cli = Cli::try_parse_from(&["essex", "completion", "bash"]).unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Bash));
@@ -189,19 +210,64 @@ mod tests {
             }
             _ => panic!("Expected Completion command"),
         }
+
+        // Test zsh completion with output
+        let cli = Cli::try_parse_from(&[
+            "essex",
+            "completion",
+            "zsh",
+            "--output",
+            "/tmp/completions",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Completion { shell, output } => {
+                assert!(matches!(shell, Shell::Zsh));
+                assert_eq!(output.unwrap(), PathBuf::from("/tmp/completions"));
+            }
+            _ => panic!("Expected Completion command"),
+        }
     }
 
     #[test]
-    fn test_validate_template() {
-        let cli = Cli::try_parse_from(["essex", "new", "basic", "test/project"]).unwrap();
-        match cli.command {
-            Commands::New {
-                template, project, ..
-            } => {
-                assert_eq!(template, "basic");
-                assert_eq!(project, "test/project");
-            }
-            _ => panic!("Expected New command"),
-        }
+    fn test_cli_execute() -> Result<()> {
+        let temp_dir = tempdir()?;
+
+        // Test list command
+        let cli = Cli::try_parse_from(&["essex", "list"]).unwrap();
+        assert!(cli.execute().is_ok());
+
+        // Test new command with invalid template
+        let cli = Cli::try_parse_from(&[
+            "essex",
+            "new",
+            "non-existent",
+            "test/project",
+        ])
+        .unwrap();
+        assert!(cli.execute().is_err());
+
+        // Test completion command
+        let completion_dir = temp_dir.path().join("completions");
+        fs::create_dir(&completion_dir)?;
+        
+        let cli = Cli::try_parse_from(&[
+            "essex",
+            "completion",
+            "bash",
+            "--output",
+            completion_dir.to_str().unwrap(),
+        ])
+        .unwrap();
+        assert!(cli.execute().is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_shell_enum() {
+        assert!(matches!(Shell::from_str("bash", true), Ok(Shell::Bash)));
+        assert!(matches!(Shell::from_str("zsh", true), Ok(Shell::Zsh)));
+        assert!(Shell::from_str("fish", true).is_err());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,14 +148,14 @@ mod tests {
 
     #[test]
     fn test_list_command_parsing() {
-        let cli = Cli::try_parse_from(&["essex", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["essex", "list"]).unwrap();
         assert!(matches!(cli.command, Commands::List));
     }
 
     #[test]
     fn test_new_command_parsing() {
         // Test basic new command
-        let cli = Cli::try_parse_from(&["essex", "new", "basic", "test/project"]).unwrap();
+        let cli = Cli::try_parse_from(["essex", "new", "basic", "test/project"]).unwrap();
         match cli.command {
             Commands::New {
                 template,
@@ -172,7 +172,7 @@ mod tests {
         }
 
         // Test new command with all options
-        let cli = Cli::try_parse_from(&[
+        let cli = Cli::try_parse_from([
             "essex",
             "new",
             "basic",
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn test_completion_command_parsing() {
         // Test bash completion
-        let cli = Cli::try_parse_from(&["essex", "completion", "bash"]).unwrap();
+        let cli = Cli::try_parse_from(["essex", "completion", "bash"]).unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Bash));
@@ -212,9 +212,8 @@ mod tests {
         }
 
         // Test zsh completion with output
-        let cli =
-            Cli::try_parse_from(&["essex", "completion", "zsh", "--output", "/tmp/completions"])
-                .unwrap();
+        let cli = Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
+            .unwrap();
         match cli.command {
             Commands::Completion { shell, output } => {
                 assert!(matches!(shell, Shell::Zsh));
@@ -229,20 +228,19 @@ mod tests {
         let temp_dir = tempdir()?;
 
         // Test list command
-        let cli = Cli::try_parse_from(&["essex", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["essex", "list"]).unwrap();
         assert!(cli.execute().is_ok());
 
         // Test new command with invalid template
-        let cli = Cli::try_parse_from(&["essex", "new", "non-existent", "test/project"]).unwrap();
+        let cli = Cli::try_parse_from(["essex", "new", "non-existent", "test/project"]).unwrap();
         assert!(cli.execute().is_err());
 
         // Test completion command
         let completion_dir = temp_dir.path().join("completions");
         fs::create_dir(&completion_dir)?;
 
-        let cli =
-            Cli::try_parse_from(&["essex", "completion", "zsh", "--output", "/tmp/completions"])
-                .unwrap();
+        let cli = Cli::try_parse_from(["essex", "completion", "zsh", "--output", "/tmp/completions"])
+            .unwrap();
         assert!(cli.execute().is_ok());
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,3 +43,57 @@ impl From<std::path::StripPrefixError> for Error {
         Error::InvalidPath(error.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_error_display() {
+        // Test IoError
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let error = Error::IoError(io_error);
+        assert!(error.to_string().contains("IO error: file not found"));
+
+        // Test TemplateError
+        let error = Error::TemplateError("invalid syntax".to_string());
+        assert!(error.to_string().contains("Template error: invalid syntax"));
+
+        // Test TemplateNotFound
+        let error = Error::TemplateNotFound("basic".to_string());
+        assert!(error.to_string().contains("Template not found: basic"));
+
+        // Test InvalidTemplate
+        let error = Error::InvalidTemplate("missing field".to_string());
+        assert!(error.to_string().contains("Invalid template: missing field"));
+
+        // Test InvalidPath
+        let error = Error::InvalidPath("invalid/path".to_string());
+        assert!(error.to_string().contains("Invalid path: invalid/path"));
+
+        // Test InvalidProjectName
+        let error = Error::InvalidProjectName("invalid name".to_string());
+        assert!(error.to_string().contains("Invalid project name: invalid name"));
+    }
+
+    #[test]
+    fn test_error_conversions() {
+        // Test From<std::io::Error>
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let error: Error = io_error.into();
+        assert!(matches!(error, Error::IoError(_)));
+
+        // Test From<tera::Error>
+        let tera_error = tera::Error::msg("template error");
+        let error: Error = tera_error.into();
+        assert!(matches!(error, Error::TemplateError(_)));
+
+        // Test From<std::path::StripPrefixError>
+        let path = Path::new("/a/b/c");
+        let base = Path::new("/x/y/z");
+        let strip_error = path.strip_prefix(base).unwrap_err();
+        let error: Error = strip_error.into();
+        assert!(matches!(error, Error::InvalidPath(_)));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,9 @@ mod tests {
 
         // Test InvalidTemplate
         let error = Error::InvalidTemplate("missing field".to_string());
-        assert!(error.to_string().contains("Invalid template: missing field"));
+        assert!(error
+            .to_string()
+            .contains("Invalid template: missing field"));
 
         // Test InvalidPath
         let error = Error::InvalidPath("invalid/path".to_string());
@@ -74,7 +76,9 @@ mod tests {
 
         // Test InvalidProjectName
         let error = Error::InvalidProjectName("invalid name".to_string());
-        assert!(error.to_string().contains("Invalid project name: invalid name"));
+        assert!(error
+            .to_string()
+            .contains("Invalid project name: invalid name"));
     }
 
     #[test]

--- a/src/template/tests.rs
+++ b/src/template/tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
     fn test_template_context_creation() {
@@ -34,5 +36,117 @@ mod tests {
     fn test_invalid_project_name() {
         let result = TemplateContext::new("invalid", None, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_template_context_validation() -> Result<()> {
+        // Test valid project name
+        let ctx = TemplateContext::new("namespace/project", None, None)?;
+        assert_eq!(ctx.repo_namespace, "namespace");
+        assert_eq!(ctx.image_name, "project");
+        assert_eq!(ctx.repo_username, "example");
+        assert_eq!(ctx.vendor, "Example Corp");
+
+        // Test custom username and vendor
+        let ctx = TemplateContext::new(
+            "custom/project",
+            Some("user123".to_string()),
+            Some("Custom Inc".to_string()),
+        )?;
+        assert_eq!(ctx.repo_username, "user123");
+        assert_eq!(ctx.vendor, "Custom Inc");
+
+        // Test invalid project names
+        assert!(TemplateContext::new("invalid", None, None).is_err());
+        assert!(TemplateContext::new("/project", None, None).is_err());
+        assert!(TemplateContext::new("namespace/", None, None).is_err());
+        assert!(TemplateContext::new("name space/project", None, None).is_err());
+        assert!(TemplateContext::new("namespace/pro ject", None, None).is_err());
+        assert!(TemplateContext::new("namespace/project!", None, None).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_context_into_context() -> Result<()> {
+        let ctx = TemplateContext::new("namespace/project", None, None)?;
+        let tera_ctx = ctx.clone().into_context();
+
+        // Verify all fields are properly inserted into the Tera context
+        assert_eq!(
+            tera_ctx.get("repo_username").unwrap().as_str().unwrap(),
+            ctx.repo_username
+        );
+        assert_eq!(
+            tera_ctx.get("repo_namespace").unwrap().as_str().unwrap(),
+            ctx.repo_namespace
+        );
+        assert_eq!(
+            tera_ctx.get("image_name").unwrap().as_str().unwrap(),
+            ctx.image_name
+        );
+        assert_eq!(tera_ctx.get("vendor").unwrap().as_str().unwrap(), ctx.vendor);
+        assert_eq!(
+            tera_ctx.get("version").unwrap().as_str().unwrap(),
+            ctx.version
+        );
+        assert_eq!(
+            tera_ctx.get("build_date").unwrap().as_str().unwrap(),
+            ctx.build_date
+        );
+        assert_eq!(
+            tera_ctx.get("vcs_ref").unwrap().as_str().unwrap(),
+            ctx.vcs_ref
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_engine_empty_dir() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let engine = TemplateEngine::new(temp_dir.path())?;
+        let templates = engine.list_templates()?;
+        assert!(!templates.is_empty(), "Should list built-in templates");
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_engine_invalid_template() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let engine = TemplateEngine::new(temp_dir.path())?;
+        let ctx = TemplateContext::new("test/project", None, None)?;
+        let result = engine.generate("non-existent", ctx, &temp_dir.path());
+        assert!(result.is_err());
+        if let Err(Error::TemplateNotFound(name)) = result {
+            assert_eq!(name, "non-existent");
+        } else {
+            panic!("Expected TemplateNotFound error");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_template_engine_async_generation() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let engine = TemplateEngine::new(temp_dir.path())?;
+        let ctx = TemplateContext::new("test/project", None, None)?;
+        
+        // Test with non-existent template
+        let result = engine
+            .generate_async("non-existent", ctx.clone(), temp_dir.path())
+            .await;
+        assert!(result.is_err());
+        
+        // Test with valid template
+        let templates = engine.list_templates()?;
+        if let Some(template) = templates.first() {
+            let result = engine
+                .generate_async(template, ctx, temp_dir.path())
+                .await;
+            assert!(result.is_ok());
+        }
+        
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes the version bump workflow by using a stable Rust toolchain instead of relying on the RUST_VERSION environment variable.