### PR TITLE
chore: update branch protection settings to match workflow job names

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -47,7 +47,7 @@ branches:
       # Require status checks
       required_status_checks:
         strict: true
-        contexts: ["cargo test", "cargo fmt", "cargo clippy"]
+        contexts: ["build-and-test (x86_64-apple-darwin)", "build-and-test (aarch64-apple-darwin)", "build-and-test (x86_64-unknown-linux-gnu)", "build-and-test (aarch64-unknown-linux-gnu)", "lint", "coverage"]
       # Include administrators
       enforce_admins: true
       # Restrict who can push to this branch


### PR DESCRIPTION
Update branch protection settings to match the actual workflow job names instead of individual command names.