### PR TITLE
fix: standardize job names in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           fail_ci_if_error: true
 
   build-and-test:
-    name: Build and Test ${{ matrix.target }}
+    name: build-and-test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:


### PR DESCRIPTION
This PR fixes the duplicate job names issue in the build workflow by standardizing the job names format. This will prevent GitHub from showing duplicate pending checks in PRs.